### PR TITLE
More output format options

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -168,15 +167,14 @@ func runFunc(fl *flags) func(cmd *cobra.Command, args []string) error {
 		poller := eval.NewStatusPoller(2*time.Second, evaluator, objects)
 		updatesChan := poller.Start(ctx)
 
-		ioStreams := genericiooptions.IOStreams{
-			In:     cmd.InOrStdin(),
-			Out:    cmd.OutOrStdout(),
-			ErrOut: cmd.ErrOrStderr(),
+		ioStreams := print.OutStreams{
+			Std: cmd.OutOrStdout(),
+			Err: cmd.ErrOrStderr(),
 		}
 		printer := print.NewTablePrinter(ioStreams, fl.printOpts())
 
 		wf := waitFunction(fl, cancelFunc)
-		print.NewPeriodicPrinter(printer, updatesChan, wf).Start()
+		print.NewPeriodicPrinter(printer, ioStreams, updatesChan, wf).Start()
 
 		return nil
 	}

--- a/pkg/print/kubectl.go
+++ b/pkg/print/kubectl.go
@@ -1,0 +1,99 @@
+package print
+
+import (
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/inecas/kube-health/pkg/status"
+)
+
+// Genric printer as a wrapper around kubectl standard printers, to produce
+// json, yaml and other standard printing capabilities.
+
+type KubectlPrinter struct {
+	Printer printers.ResourcePrinter
+}
+
+type objectWrapper struct {
+	Object     corev1.ObjectReference   `json:"object"`
+	Status     status.Status            `json:"health"`
+	Conditions []status.ConditionStatus `json:"conditions,omitempty"`
+	Subobjects []*objectWrapper         `json:"subobjects,omitempty"`
+}
+
+// objectWrapper implements runtime.Object interface
+var _ runtime.Object = &objectWrapper{}
+
+func (ow *objectWrapper) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+
+}
+
+func (ow *objectWrapper) DeepCopyObject() runtime.Object {
+	return ow.DeepCopy()
+}
+
+func (ow *objectWrapper) DeepCopy() *objectWrapper {
+	var conditions []status.ConditionStatus
+	for _, c := range ow.Conditions {
+		conditions = append(conditions, *c.DeepCopy())
+	}
+
+	var subobjects []*objectWrapper
+	for _, o := range ow.Subobjects {
+		subobjects = append(subobjects, o.DeepCopy())
+	}
+
+	return &objectWrapper{
+		Object:     *ow.Object.DeepCopy(),
+		Status:     *ow.Status.DeepCopy(),
+		Conditions: conditions,
+		Subobjects: subobjects,
+	}
+}
+
+func wrapObjectStatus(s status.ObjectStatus) *objectWrapper {
+	ret := objectWrapper{
+		Object: corev1.ObjectReference{
+			APIVersion: s.Object.APIVersion,
+			Kind:       s.Object.Kind,
+			Name:       s.Object.Name,
+			Namespace:  s.Object.Namespace,
+			UID:        s.Object.UID,
+		},
+		Status:     s.ObjStatus,
+		Conditions: s.Conditions,
+	}
+
+	for _, ss := range s.SubStatuses {
+		ret.Subobjects = append(ret.Subobjects, wrapObjectStatus(ss))
+	}
+
+	return &ret
+}
+
+func (p KubectlPrinter) PrintStatuses(statuses []status.ObjectStatus, w io.Writer) {
+	objects := make([]runtime.Object, 0, len(statuses))
+	for _, s := range statuses {
+		objects = append(objects, wrapObjectStatus(s))
+	}
+
+	list := &corev1.List{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+	}
+	if err := meta.SetList(list, objects); err != nil {
+		panic(err)
+	}
+
+	p.Printer.PrintObj(list, w)
+}

--- a/pkg/print/periodic.go
+++ b/pkg/print/periodic.go
@@ -53,7 +53,7 @@ func (p *PeriodicPrinter) Start() {
 		}
 		p.resetScreen()
 
-		// Wrap writer to count number of emitted lines.
+		// Wrap writer to count number of emited lines.
 		lcw := &lineCountWriter{w: p.out.Std}
 		p.printer.PrintStatuses(update.Statuses, lcw)
 		p.previousLines = lcw.lines

--- a/pkg/print/periodic.go
+++ b/pkg/print/periodic.go
@@ -1,6 +1,10 @@
 package print
 
 import (
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/inecas/kube-health/pkg/eval"
 	"github.com/inecas/kube-health/pkg/status"
 )
@@ -11,15 +15,31 @@ import (
 // the next update.
 type PeriodicPrinter struct {
 	printer       StatusPrinter
+	out           OutStreams
 	previousLines int
 	updateChan    <-chan eval.StatusUpdate
 	callback      func([]status.ObjectStatus)
 }
 
-func NewPeriodicPrinter(printer StatusPrinter, updateChan <-chan eval.StatusUpdate,
+type lineCountWriter struct {
+	w     io.Writer
+	lines int
+}
+
+func (lcw *lineCountWriter) Write(p []byte) (n int, err error) {
+	n, err = lcw.w.Write(p)
+	var sb strings.Builder
+	sb.Write(p[:n])
+	lcw.lines += strings.Count(sb.String(), "\n")
+
+	return n, err
+}
+
+func NewPeriodicPrinter(printer StatusPrinter, out OutStreams, updateChan <-chan eval.StatusUpdate,
 	callback func([]status.ObjectStatus)) *PeriodicPrinter {
 	return &PeriodicPrinter{
 		printer:    printer,
+		out:        out,
 		updateChan: updateChan,
 		callback:   callback,
 	}
@@ -27,12 +47,17 @@ func NewPeriodicPrinter(printer StatusPrinter, updateChan <-chan eval.StatusUpda
 
 func (p *PeriodicPrinter) Start() {
 	for update := range p.updateChan {
-		p.resetScreen()
 		if update.Error != nil {
-			p.printer.PrintError(update.Error)
+			fmt.Fprintf(p.out.Err, "Error: %s", update.Error)
 			p.previousLines = 0
 		}
-		p.previousLines = p.printer.PrintStatuses(update.Statuses)
+		p.resetScreen()
+
+		// Wrap writer to count number of emitted lines.
+		lcw := &lineCountWriter{w: p.out.Std}
+		p.printer.PrintStatuses(update.Statuses, lcw)
+		p.previousLines = lcw.lines
+
 		if p.callback != nil {
 			p.callback(update.Statuses)
 		}
@@ -47,9 +72,9 @@ func (p *PeriodicPrinter) resetScreen() {
 }
 
 func (p *PeriodicPrinter) moveUp() {
-	p.printer.Printf("%c[%dA", ESC, 1)
+	fmt.Fprintf(p.out.Std, "%c[%dA", ESC, 1)
 }
 
 func (p *PeriodicPrinter) eraseCurrentLine() {
-	p.printer.Printf("%c[2K\r", ESC)
+	fmt.Fprintf(p.out.Std, "%c[2K\r", ESC)
 }

--- a/pkg/print/printer.go
+++ b/pkg/print/printer.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"io"
+
 	"github.com/inecas/kube-health/pkg/status"
 )
 
@@ -10,9 +12,13 @@ type PrintOptions struct {
 	Width     int  // Width of the output. If 0, wrapping is disabled.
 }
 
+// Simplified printer that allows formatting to stdout and stderr.
+type OutStreams struct {
+	Std io.Writer
+	Err io.Writer
+}
+
 // StatusPrinter is an interface for printing status updates.
 type StatusPrinter interface {
-	PrintStatuses(statuses []status.ObjectStatus) int
-	PrintError(err error) int
-	Printf(raw string, args ...interface{})
+	PrintStatuses(statuses []status.ObjectStatus, w io.Writer)
 }

--- a/pkg/print/printer.go
+++ b/pkg/print/printer.go
@@ -10,9 +10,9 @@ type PrintOptions struct {
 	ShowGroup bool // By default, group names are not shown.
 	ShowOk    bool // By default, OK statuses are not shown.
 	Width     int  // Width of the output. If 0, wrapping is disabled.
+	Color     bool // Use colors to indicate the health.
 }
 
-// Simplified printer that allows formatting to stdout and stderr.
 type OutStreams struct {
 	Std io.Writer
 	Err io.Writer

--- a/pkg/print/table.go
+++ b/pkg/print/table.go
@@ -195,13 +195,11 @@ func formatObject(obj status.ObjectStatus, root, printGroups bool) string {
 // TablePrinter implements StatusPrinter interface for printing the status
 // of resources in a tabular format.
 type TablePrinter struct {
-	Out       OutStreams
 	PrintOpts PrintOptions
 }
 
-func NewTablePrinter(out OutStreams, opts PrintOptions) *TablePrinter {
+func NewTablePrinter(opts PrintOptions) *TablePrinter {
 	return &TablePrinter{
-		Out:       out,
 		PrintOpts: opts,
 	}
 }


### PR DESCRIPTION
This PR adds `-o` options, that supports the standard output types known in kubectl, such as `json`, `yaml`….

It also allows disabling the color output by passing `-o=tree`. Color is enabled by default using the `tree+color` output format.

Sample no-color output:

```
OBJECT           CONDITION                       AGE    REASON
Error demo/Deployment/nginx
│                (Error) Available=False         121h   MinimumReplicasUnavailable
│                  Deployment does not have minimum availability.
│                (Error) Progressing=False       121h   ProgressDeadlineExceeded
│                  ReplicaSet "nginx-6d667dd76" has timed out progressing.
├─ Error ReplicaSet/nginx-6d667dd76
│  │             (Error) ReplicasAvailable=Fals         Unavailable
│  │               Available: 0/1
│  │             (Error) ReplicasReady=False            NotReady
│  │               Ready: 0/1
│  └─ Unknown Pod/nginx-6d667dd76-nzkcp
└─ Error ReplicaSet/nginx-c49474db8
   │             (Error) ReplicasAvailable=Fals         Unavailable
   │               Available: 0/1
   │             (Error) ReplicasReady=False            NotReady
   │               Ready: 0/1
   └─ Ok Pod/nginx-c49474db8-b9vg9
```

Sample yaml output:

```yaml
apiVersion: v1
kind: List
metadata: {}
items:
-  object:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
    namespace: demo
    uid: 8841ef25-4cd8-4633-b680-269be2038c1b
  health:
    progressing: false
    result: error
  conditions:
  - health:
      progressing: false
      result: error
    lastTransitionTime: "2025-01-16T11:53:41Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - health:
      progressing: false
      result: error
    lastTransitionTime: "2025-01-16T12:08:00Z"
    message: ReplicaSet "nginx-6d667dd76" has timed out progressing.
    reason: ProgressDeadlineExceeded
    status: "False"
    type: Progressing
  subobjects:
  - object:
      apiVersion: apps/v1
      kind: ReplicaSet
      name: nginx-6d667dd76
      namespace: demo
      uid: 3b0b3586-7b6e-48f5-ab7e-7bf58564f4fa
    health:
      progressing: false
      result: error
    conditions:
    - lastTransitionTime: null
      message: 'Available: 0/1'
      reason: Unavailable
      status: "False"
      type: ReplicasAvailable
      health:
        progressing: false
        result: error
    - lastTransitionTime: null
      message: 'Ready: 0/1'
      reason: NotReady
      status: "False"
      type: ReplicasReady
      health:
        progressing: false
        result: error
```

Fixes #3 
