### PR TITLE
do not store context in Evaluator type

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -215,7 +215,7 @@ func runFunc(fl *flags) func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Can't create loader: %w", err)
 		}
 
-		evaluator := eval.NewEvaluator(ctx, analyze.DefaultAnalyzers(), ldr)
+		evaluator := eval.NewEvaluator(analyze.DefaultAnalyzers(), ldr)
 
 		poller := eval.NewStatusPoller(2*time.Second, evaluator, objects)
 		updatesChan := poller.Start(ctx)

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -104,7 +104,7 @@ func runFunc(fl *flags) func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Can't create loader: %w", err)
 		}
 
-		evaluator := eval.NewEvaluator(ctx, analyze.DefaultAnalyzers(), ldr)
+		evaluator := eval.NewEvaluator(analyze.DefaultAnalyzers(), ldr)
 
 		interval := time.Duration(fl.interval) * time.Second
 		poller := monitor.NewMonitorPoller(interval, evaluator, cfg)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -67,7 +67,7 @@ func (_ MyAnalyzer) Supports(obj *status.Object) bool {
 }
 
 // Analyze gets called for each object supported by the analyzer.
-func (_ MyAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (_ MyAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	myresult, found, err := unstructured.NestedString(obj.Unstructured.Object, "status", "myresult")
 
 	// If evaluation fails, use UnknownStatusWithError.
@@ -123,9 +123,9 @@ func (_ MyAnalyzer) Supports(obj *status.Object) bool {
 		schema.GroupKind{Group: "mygroup.example.org", Kind: "MyResource"})
 }
 
-func (a MyAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (a MyAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	// Evaluate sub-objects based on owner references.
-	subStatuses, err := a.e.EvalQuery(analyze.GenericOwnerQuerySpec(obj), nil)
+	subStatuses, err := a.e.EvalQuery(ctx, analyze.GenericOwnerQuerySpec(obj), nil)
 
 	// The GenericConditionAnalyzer looks at presence of specific conditions.
 	// By default it considers True conditions to be Ok, unless they are listed

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ func TestEvaluator(testdata ...string) (*eval.Evaluator, *eval.FakeLoader, []*st
 		objs = append(objs, RegisterTestData(loader, t)...)
 	}
 
-	evaluator := eval.NewEvaluator(context.Background(), analyze.DefaultAnalyzers(), loader)
+	evaluator := eval.NewEvaluator(analyze.DefaultAnalyzers(), loader)
 	return evaluator, loader, objs
 }
 

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -142,7 +143,7 @@ func (a AlwaysGreenAnalyzer) Supports(obj *status.Object) bool {
 	return slices.Contains(a.Kinds, obj.GroupVersionKind().GroupKind())
 }
 
-func (a AlwaysGreenAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (a AlwaysGreenAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	return status.OkStatus(obj, nil)
 }
 

--- a/pkg/analyze/deployment.go
+++ b/pkg/analyze/deployment.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,8 +22,8 @@ func (_ DeploymentAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkDeployment
 }
 
-func (a DeploymentAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
-	subStatuses, err := a.e.EvalQuery(
+func (a DeploymentAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
+	subStatuses, err := a.e.EvalQuery(ctx,
 		eval.NewSelectorLabelQuerySpec(obj, gkReplicaSet), ReplicaSetAnalyzer{e: a.e})
 
 	if err != nil {

--- a/pkg/analyze/deployment_test.go
+++ b/pkg/analyze/deployment_test.go
@@ -1,6 +1,7 @@
 package analyze_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -14,10 +15,10 @@ import (
 func TestDeploymentAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 	p := print.NewTreePrinter(print.PrintOptions{ShowOk: true})
-
+	ctx := context.Background()
 	e, l, objs := test.TestEvaluator("deployments.yaml", "pods.yaml", "replicasets.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
@@ -41,7 +42,7 @@ Ok default/Deployment/dp1
 	`, sb.String())
 
 	l.RegisterPodLogs("default", "p2", "p2c", "Line 1\nLine 2\nLine 3\n")
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.True(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/generic.go
+++ b/pkg/analyze/generic.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -22,8 +23,8 @@ func (a *GenericAnalyzer) Supports(obj *status.Object) bool {
 	return true
 }
 
-func (a *GenericAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
-	subStatuses, err := a.e.EvalQuery(GenericOwnerQuerySpec(obj), nil)
+func (a *GenericAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
+	subStatuses, err := a.e.EvalQuery(ctx, GenericOwnerQuerySpec(obj), nil)
 	if err != nil {
 		return status.UnknownStatusWithError(obj, err)
 	}

--- a/pkg/analyze/pod_test.go
+++ b/pkg/analyze/pod_test.go
@@ -1,6 +1,7 @@
 package analyze_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -11,15 +12,15 @@ import (
 
 func TestPodAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-
+	ctx := context.Background()
 	e, l, objs := test.TestEvaluator("pods.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
 	l.RegisterPodLogs("default", "p2", "p2c", "Line 1\nLine 2\nLine 3\n")
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/pvc.go
+++ b/pkg/analyze/pvc.go
@@ -1,6 +1,8 @@
 package analyze
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -20,7 +22,7 @@ func (_ PVCAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkPvc
 }
 
-func (a PVCAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (a PVCAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	phase, _, _ := unstructured.NestedString(obj.Unstructured.Object, "status", "phase")
 	var conditions []status.ConditionStatus
 	if phase != "Bound" {

--- a/pkg/analyze/pvc_test.go
+++ b/pkg/analyze/pvc_test.go
@@ -1,6 +1,7 @@
 package analyze_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -11,15 +12,15 @@ import (
 
 func TestPvcAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-
+	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("pvcs.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `Bound  PVC is bound. (Ok)`, os.Conditions)
 
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.True(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Unknown)
 

--- a/pkg/analyze/redhat/clusteroperator.go
+++ b/pkg/analyze/redhat/clusteroperator.go
@@ -1,6 +1,8 @@
 package redhat
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/inecas/kube-health/pkg/analyze"
@@ -26,7 +28,7 @@ func (_ ClusterOperatorAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkClusterOperator
 }
 
-func (_ ClusterOperatorAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (_ ClusterOperatorAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	conditionAnalyzers := append([]analyze.ConditionAnalyzer{clusteroperatorConditionsAnalyzer},
 		analyze.DefaultConditionAnalyzers...,
 	)

--- a/pkg/analyze/redhat/clusteroperator_test.go
+++ b/pkg/analyze/redhat/clusteroperator_test.go
@@ -1,6 +1,7 @@
 package redhat_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -14,7 +15,7 @@ func TestClusterOperatorAnalyzer(t *testing.T) {
 
 	e, _, objs := test.TestEvaluator("clusteroperators.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(context.Background(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `
@@ -24,7 +25,7 @@ Available WaitingForProvisioningCR Waiting for Provisioning CR (Ok)
 Upgradeable   (Unknown)
 Disabled   (Unknown)`, os.Conditions)
 
-	os = e.Eval(objs[1])
+	os = e.Eval(context.Background(), objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/redhat/mco.go
+++ b/pkg/analyze/redhat/mco.go
@@ -2,6 +2,8 @@ package redhat
 
 // mco.go implements an analyzer for MultiClusterObservability objects.
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/inecas/kube-health/pkg/analyze"
@@ -23,12 +25,12 @@ func (_ MCOAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkMCO
 }
 
-func (a MCOAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (a MCOAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	// We need to specify the namespace explicitly, as the MCO object
 	// is namespace-less.
 	ds := analyze.GenericOwnerQuerySpec(obj)
 	ds.NamespaceOverride = &mcoNs
-	subStatuses, err := a.e.EvalQuery(ds, nil)
+	subStatuses, err := a.e.EvalQuery(ctx, ds, nil)
 
 	conditions, err := analyze.AnalyzeObjectConditions(obj, analyze.DefaultConditionAnalyzers)
 

--- a/pkg/analyze/redhat/mco_test.go
+++ b/pkg/analyze/redhat/mco_test.go
@@ -1,6 +1,7 @@
 package redhat_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -14,7 +15,7 @@ func TestMcoAnalyzer(t *testing.T) {
 
 	e, _, objs := test.TestEvaluator("mcos.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(context.Background(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `
@@ -25,7 +26,7 @@ Updated  All nodes are updated (Unknown)
 Updating   (Unknown)
 `, os.Conditions)
 
-	os = e.Eval(objs[1])
+	os = e.Eval(context.Background(), objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/redhat/olm_test.go
+++ b/pkg/analyze/redhat/olm_test.go
@@ -1,6 +1,7 @@
 package redhat_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -14,17 +15,18 @@ import (
 func TestOlmAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 	p := print.NewTreePrinter(print.PrintOptions{ShowOk: true})
+	ctx := context.Background()
 
 	e, _, objs := test.TestEvaluator("olm_subscriptions.yaml", "olm_install_plans.yaml", "olm_csvs.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `
 CatalogSourcesUnhealthy AllCatalogSourcesHealthy all available catalogsources are healthy (Ok)
 `, os.Conditions)
 
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.True(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `
@@ -32,7 +34,7 @@ CatalogSourcesUnhealthy AllCatalogSourcesHealthy all available catalogsources ar
 InstallPlan InstallPlanMissing Install plan not found (Unknown)
 `, os.Conditions)
 
-	os = e.Eval(objs[2])
+	os = e.Eval(ctx, objs[2])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 	test.AssertConditions(t, `

--- a/pkg/analyze/redhat/route.go
+++ b/pkg/analyze/redhat/route.go
@@ -1,6 +1,8 @@
 package redhat
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -22,7 +24,7 @@ func (_ RouteAnalyzer) Supports(obj *status.Object) bool {
 		schema.GroupKind{Group: "route.openshift.io", Kind: "Route"})
 }
 
-func (_ RouteAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
+func (_ RouteAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
 	var conditions []status.ConditionStatus
 
 	ingresses, _, _ := unstructured.NestedSlice(obj.Unstructured.Object, "status", "ingress")

--- a/pkg/analyze/redhat/route_test.go
+++ b/pkg/analyze/redhat/route_test.go
@@ -1,6 +1,7 @@
 package redhat_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -12,14 +13,15 @@ import (
 func TestRouteAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 
+	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("routes.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `Admitted   (Ok)`, os.Conditions)
 
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/replicaset.go
+++ b/pkg/analyze/replicaset.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,8 +24,8 @@ func (_ ReplicaSetAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkReplicaSet
 }
 
-func (a ReplicaSetAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
-	subStatuses, err := a.e.EvalQuery(
+func (a ReplicaSetAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
+	subStatuses, err := a.e.EvalQuery(ctx,
 		eval.NewSelectorLabelQuerySpec(obj, gkPod), PodAnalyzer{e: a.e})
 
 	if err != nil {

--- a/pkg/analyze/replicaset_test.go
+++ b/pkg/analyze/replicaset_test.go
@@ -1,6 +1,7 @@
 package analyze_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -11,10 +12,10 @@ import (
 
 func TestReplicaSetAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-
+	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("replicasets.yaml", "pods.yaml")
 
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/service.go
+++ b/pkg/analyze/service.go
@@ -1,6 +1,8 @@
 package analyze
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/inecas/kube-health/pkg/eval"
@@ -19,8 +21,8 @@ func (_ ServiceAnalyzer) Supports(obj *status.Object) bool {
 	return obj.GroupVersionKind().GroupKind() == gkService
 }
 
-func (a ServiceAnalyzer) Analyze(obj *status.Object) status.ObjectStatus {
-	subStatuses, err := a.e.EvalQuery(
+func (a ServiceAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
+	subStatuses, err := a.e.EvalQuery(ctx,
 		eval.NewSelectorLabelEqualityQuerySpec(obj, gkPod), PodAnalyzer{e: a.e})
 
 	if err != nil {

--- a/pkg/analyze/service_test.go
+++ b/pkg/analyze/service_test.go
@@ -1,6 +1,7 @@
 package analyze_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -14,10 +15,10 @@ import (
 func TestServiceAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 	p := print.NewTreePrinter(print.PrintOptions{ShowOk: true})
-
+	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("services.yaml", "pods.yaml")
 
-	os = e.Eval(objs[0])
+	os = e.Eval(ctx, objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
@@ -36,7 +37,7 @@ Ok default/Service/s1
                  Running=True                    24h
 `, sb.String())
 
-	os = e.Eval(objs[1])
+	os = e.Eval(ctx, objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/eval/poll.go
+++ b/pkg/eval/poll.go
@@ -36,13 +36,13 @@ func (s *StatusPoller) Start(ctx context.Context) <-chan StatusUpdate {
 	go func() {
 		defer close(s.eventChan)
 		// Initial run
-		s.run()
+		s.run(ctx)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(s.interval):
-				s.run()
+				s.run(ctx)
 			}
 		}
 	}()
@@ -50,13 +50,13 @@ func (s *StatusPoller) Start(ctx context.Context) <-chan StatusUpdate {
 	return s.eventChan
 }
 
-func (s *StatusPoller) run() {
+func (s *StatusPoller) run(ctx context.Context) {
 	// Reset the evaluator to clear the cache from previous run.
 	s.evaluator.Reset()
 
 	statuses := make([]status.ObjectStatus, 0, len(s.objects))
 	for _, obj := range s.objects {
-		statuses = append(statuses, s.evaluator.Eval(obj))
+		statuses = append(statuses, s.evaluator.Eval(ctx, obj))
 	}
 
 	s.eventChan <- StatusUpdate{

--- a/pkg/eval/query.go
+++ b/pkg/eval/query.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 
@@ -39,7 +40,7 @@ type QuerySpec interface {
 	// If applicable, the loader is already preloaded with the objects based
 	// on the GroupKindMatcher and Namespace. It's still the repsonsibility
 	// of the Eval method to do the final filtering.
-	Eval(e *Evaluator) []*status.Object
+	Eval(ctx context.Context, e *Evaluator) []*status.Object
 }
 
 // GroupKindMatcher allows specifying a set of kinds to match.
@@ -187,7 +188,7 @@ func (qs KindQuerySpec) GroupKindMatcher() GroupKindMatcher {
 	return qs.GK
 }
 
-func (qs KindQuerySpec) Eval(e *Evaluator) []*status.Object {
+func (qs KindQuerySpec) Eval(ctx context.Context, e *Evaluator) []*status.Object {
 	return e.Filter(qs.Namespace(), qs.GK)
 }
 
@@ -211,7 +212,7 @@ func (qs OwnerQuerySpec) GroupKindMatcher() GroupKindMatcher {
 	return qs.GK
 }
 
-func (qs OwnerQuerySpec) Eval(e *Evaluator) []*status.Object {
+func (qs OwnerQuerySpec) Eval(ctx context.Context, e *Evaluator) []*status.Object {
 	candidates := e.Filter(qs.Namespace(), qs.GK)
 	return e.filterOwnedBy(qs.Object, candidates)
 }
@@ -248,7 +249,7 @@ func (qs LabelQuerySpec) Namespace() string {
 	return qs.Object.GetNamespace()
 }
 
-func (qs LabelQuerySpec) Eval(e *Evaluator) []*status.Object {
+func (qs LabelQuerySpec) Eval(ctx context.Context, e *Evaluator) []*status.Object {
 	candidates := e.Filter(qs.Object.GetNamespace(), qs.GK)
 	var ret []*status.Object
 	if qs.Selector == nil {
@@ -336,7 +337,7 @@ func (qs RefQuerySpec) Namespace() string {
 	return qs.Object.GetNamespace()
 }
 
-func (qs RefQuerySpec) Eval(e *Evaluator) []*status.Object {
+func (qs RefQuerySpec) Eval(ctx context.Context, e *Evaluator) []*status.Object {
 	candidates := e.Filter(qs.Object.GetNamespace(), qs.GroupKindMatcher())
 	var ret []*status.Object
 
@@ -365,9 +366,9 @@ func (qs PodLogQuerySpec) Namespace() string {
 	return qs.Object.GetNamespace()
 }
 
-func (qs PodLogQuerySpec) Eval(e *Evaluator) []*status.Object {
+func (qs PodLogQuerySpec) Eval(ctx context.Context, e *Evaluator) []*status.Object {
 	data := make(map[string]interface{}, 1)
-	logs, err := e.loader.LoadPodLogs(e.ctx, qs.Object, qs.Container, 5)
+	logs, err := e.loader.LoadPodLogs(ctx, qs.Object, qs.Container, 5)
 	if err != nil {
 		klog.V(4).ErrorS(err, "Failed to get logs", "object", qs.Object)
 	} else {

--- a/pkg/monitor/poll.go
+++ b/pkg/monitor/poll.go
@@ -53,13 +53,13 @@ func (s *MonitorPoller) Start(ctx context.Context) <-chan TargetsStatusUpdate {
 	go func() {
 		defer close(s.eventChan)
 		// Initial run
-		s.run()
+		s.run(ctx)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(s.interval):
-				s.run()
+				s.run(ctx)
 			}
 		}
 	}()
@@ -67,7 +67,7 @@ func (s *MonitorPoller) Start(ctx context.Context) <-chan TargetsStatusUpdate {
 	return s.eventChan
 }
 
-func (s *MonitorPoller) run() {
+func (s *MonitorPoller) run(ctx context.Context) {
 	// Reset the evaluator to clear the cache from previous run.
 	s.evaluator.Reset()
 
@@ -82,7 +82,7 @@ func (s *MonitorPoller) run() {
 			// TODO: add namespace support
 			//Namespace: target.Namespace,
 		}
-		s, err := s.evaluator.EvalQuery(querySpec, nil)
+		s, err := s.evaluator.EvalQuery(ctx, querySpec, nil)
 		if err != nil {
 			klog.ErrorS(err, "failed to evaluate query", "query", querySpec)
 			continue


### PR DESCRIPTION
This is more a cosmetic change (feel free to close) to follow the Go's [context package recommendation](https://pkg.go.dev/context#pkg-overview):

> Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it. 