### PR TITLE
feat: extend clusteroperator analyzer to check related objects

### DIFF
--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -150,8 +150,9 @@ func (a AlwaysGreenAnalyzer) Analyze(ctx context.Context, obj *status.Object) st
 // AnalyzerRegister is a registry of analyzers.
 // It allows to register new analyzers and ignored GroupKinds.
 type AnalyzerRegister struct {
-	analyzerInits []eval.AnalyzerInit
-	ignored       []schema.GroupKind
+	analyzerInits    []eval.AnalyzerInit
+	ignoredKinds     []schema.GroupKind
+	ignoredResources []schema.GroupResource
 }
 
 // Register registers new analyzers.
@@ -168,8 +169,16 @@ func (r *AnalyzerRegister) RegisterSimple(as ...eval.Analyzer) {
 	}
 }
 
+func (r *AnalyzerRegister) RegisterIgnoredResources(gr ...schema.GroupResource) {
+	r.ignoredResources = append(r.ignoredResources, gr...)
+}
+
+func (r AnalyzerRegister) IgnoredResources() []schema.GroupResource {
+	return r.ignoredResources
+}
+
 func (r *AnalyzerRegister) RegisterIgnoredKinds(gk ...schema.GroupKind) {
-	r.ignored = append(r.ignored, gk...)
+	r.ignoredKinds = append(r.ignoredKinds, gk...)
 }
 
 func (r *AnalyzerRegister) AnalyzerInits() []eval.AnalyzerInit {

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -168,8 +168,8 @@ func (r *AnalyzerRegister) RegisterSimple(as ...eval.Analyzer) {
 	}
 }
 
-func (r AnalyzerRegister) IgnoredKinds() []schema.GroupKind {
-	return r.ignored
+func (r AnalyzerRegister) IsIgnoredKind(gvk schema.GroupKind) bool {
+	return slices.Contains(r.ignored, gvk)
 }
 
 func (r *AnalyzerRegister) RegisterIgnoredKinds(gk ...schema.GroupKind) {

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -151,7 +151,7 @@ func (a AlwaysGreenAnalyzer) Analyze(ctx context.Context, obj *status.Object) st
 // It allows to register new analyzers and ignored GroupKinds.
 type AnalyzerRegister struct {
 	analyzerInits []eval.AnalyzerInit
-	ignoredKinds  []schema.GroupKind
+	ignored       []schema.GroupKind
 }
 
 // Register registers new analyzers.
@@ -169,11 +169,11 @@ func (r *AnalyzerRegister) RegisterSimple(as ...eval.Analyzer) {
 }
 
 func (r AnalyzerRegister) IgnoredKinds() []schema.GroupKind {
-	return r.ignoredKinds
+	return r.ignored
 }
 
 func (r *AnalyzerRegister) RegisterIgnoredKinds(gk ...schema.GroupKind) {
-	r.ignoredKinds = append(r.ignoredKinds, gk...)
+	r.ignored = append(r.ignored, gk...)
 }
 
 func (r *AnalyzerRegister) AnalyzerInits() []eval.AnalyzerInit {

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -150,9 +150,8 @@ func (a AlwaysGreenAnalyzer) Analyze(ctx context.Context, obj *status.Object) st
 // AnalyzerRegister is a registry of analyzers.
 // It allows to register new analyzers and ignored GroupKinds.
 type AnalyzerRegister struct {
-	analyzerInits    []eval.AnalyzerInit
-	ignoredKinds     []schema.GroupKind
-	ignoredResources []schema.GroupResource
+	analyzerInits []eval.AnalyzerInit
+	ignoredKinds  []schema.GroupKind
 }
 
 // Register registers new analyzers.
@@ -169,12 +168,8 @@ func (r *AnalyzerRegister) RegisterSimple(as ...eval.Analyzer) {
 	}
 }
 
-func (r *AnalyzerRegister) RegisterIgnoredResources(gr ...schema.GroupResource) {
-	r.ignoredResources = append(r.ignoredResources, gr...)
-}
-
-func (r AnalyzerRegister) IgnoredResources() []schema.GroupResource {
-	return r.ignoredResources
+func (r AnalyzerRegister) IgnoredKinds() []schema.GroupKind {
+	return r.ignoredKinds
 }
 
 func (r *AnalyzerRegister) RegisterIgnoredKinds(gk ...schema.GroupKind) {

--- a/pkg/analyze/generic.go
+++ b/pkg/analyze/generic.go
@@ -53,7 +53,7 @@ func GenericOwnerQuerySpec(obj *status.Object) eval.OwnerQuerySpec {
 		Object: obj,
 		GK: eval.GroupKindMatcher{
 			IncludeAll:    true,
-			ExcludedKinds: Register.ignoredKinds,
+			ExcludedKinds: Register.ignored,
 		},
 	}
 }

--- a/pkg/analyze/generic.go
+++ b/pkg/analyze/generic.go
@@ -53,7 +53,7 @@ func GenericOwnerQuerySpec(obj *status.Object) eval.OwnerQuerySpec {
 		Object: obj,
 		GK: eval.GroupKindMatcher{
 			IncludeAll:    true,
-			ExcludedKinds: Register.ignored,
+			ExcludedKinds: Register.ignoredKinds,
 		},
 	}
 }

--- a/pkg/analyze/redhat/clusteroperator.go
+++ b/pkg/analyze/redhat/clusteroperator.go
@@ -112,5 +112,7 @@ func init() {
 		schema.GroupKind{Kind: "ConsolePlugin", Group: "console.openshift.io"},
 		schema.GroupKind{Kind: "MachineConfig", Group: "machineconfiguration.openshift.io"},
 		schema.GroupKind{Kind: "Template", Group: "template.openshift.io"},
+		schema.GroupKind{Kind: "ServiceMonitor", Group: "monitoring.coreos.com"},
+		schema.GroupKind{Kind: "PrometheusRule", Group: "monitoring.coreos.com"},
 	)
 }

--- a/pkg/analyze/redhat/clusteroperator.go
+++ b/pkg/analyze/redhat/clusteroperator.go
@@ -47,6 +47,12 @@ func (c *ClusterOperatorAnalyzer) Analyze(ctx context.Context, obj *status.Objec
 		return status.UnknownStatusWithError(obj, err)
 	}
 
+	// cloud-controller-manager references itself in the related objects
+	// so this is to avoid endless loop
+	if obj.Name == "cloud-controller-manager" {
+		return analyze.AggregateResult(obj, nil, conditions)
+	}
+
 	relatedObjects, _, err := unstructured.NestedSlice(obj.Unstructured.Object, "status", "relatedObjects")
 	if err != nil {
 		// do not add any substatuses in case of error

--- a/pkg/analyze/redhat/clusteroperator.go
+++ b/pkg/analyze/redhat/clusteroperator.go
@@ -62,7 +62,9 @@ func (c *ClusterOperatorAnalyzer) Analyze(ctx context.Context, obj *status.Objec
 func (c *ClusterOperatorAnalyzer) evaluateRelatedObjects(ctx context.Context, objectInfos []objectInfo) []status.ObjectStatus {
 	var statuses []status.ObjectStatus
 	for _, objInfo := range objectInfos {
-		if analyze.Register.IsIgnoredKind(c.evaluator.ResourceToKind(objInfo.groupResource).GroupKind()) {
+		gk := c.evaluator.ResourceToKind(objInfo.groupResource).GroupKind()
+		if analyze.Register.IsIgnoredKind(gk) {
+			klog.V(7).Infof("%s kind (in group %s) is registered as ignored", gk.Kind, gk.Group)
 			continue
 		}
 		relObjectsStatuses, err := c.evaluator.EvalResource(ctx, objInfo.groupResource, objInfo.namespace, objInfo.name)
@@ -107,6 +109,7 @@ func adaptRelatedObjects(parent *status.Object, relatedObjects []interface{}) []
 		}
 		// some clusteroperators references themselves in the relatedObjects
 		if parent.Name == name {
+			klog.V(7).Infof("%s.%s seems to reference itself", name, gr)
 			continue
 		}
 		adaptedObjects = append(adaptedObjects, objInf)

--- a/pkg/analyze/redhat/clusteroperator.go
+++ b/pkg/analyze/redhat/clusteroperator.go
@@ -69,12 +69,15 @@ func (c *ClusterOperatorAnalyzer) evaluateRelatedObjects(ctx context.Context, re
 
 		gr := schema.GroupResource{Group: group, Resource: resource}
 
-		if slices.Contains(analyze.Register.IgnoredResources(), gr) {
+		if slices.Contains(analyze.Register.IgnoredKinds(), c.evaluator.ResourceToKind(gr).GroupKind()) {
 			continue
 		}
+		var namespace string
+		if ns, ok := relObjecMap["namespace"]; ok {
+			namespace = ns.(string)
+		}
 		name := relObjecMap["name"].(string)
-		// TODO try to get namespace name
-		relObjectsStatuses, err := c.evaluator.EvalResource(ctx, gr, "", name)
+		relObjectsStatuses, err := c.evaluator.EvalResource(ctx, gr, namespace, name)
 		if err != nil {
 			continue
 		}
@@ -90,18 +93,24 @@ func init() {
 		}
 	})
 
-	analyze.Register.RegisterIgnoredResources(
-		schema.GroupResource{Resource: "namespaces"},
-		schema.GroupResource{Resource: "secrets"},
-		schema.GroupResource{Resource: "configmaps"},
-		schema.GroupResource{Resource: "clusterroles", Group: "rbac.authorization.k8s.io"},
-		schema.GroupResource{Resource: "clusterrolebindings", Group: "rbac.authorization.k8s.io"},
-		schema.GroupResource{Resource: "roles", Group: "rbac.authorization.k8s.io"},
-		schema.GroupResource{Resource: "rolesbindings", Group: "rbac.authorization.k8s.io"},
-		schema.GroupResource{Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io"},
-		schema.GroupResource{Resource: "securitycontextconstraints", Group: "security.openshift.io"},
-		schema.GroupResource{Resource: "validatingwebhookconfigurations", Group: "admissionregistration.k8s.io"},
-		schema.GroupResource{Resource: "mutatingwebhookconfigurations", Group: "admissionregistration.k8s.io"},
+	analyze.Register.RegisterIgnoredKinds(
+		schema.GroupKind{Kind: "Namespace"},
+		schema.GroupKind{Kind: "Secret"},
+		schema.GroupKind{Kind: "ConfigMap"},
+		schema.GroupKind{Kind: "ServiceAccount"},
+		schema.GroupKind{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"},
+		schema.GroupKind{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"},
+		schema.GroupKind{Kind: "Role", Group: "rbac.authorization.k8s.io"},
+		schema.GroupKind{Kind: "RoleBinding", Group: "rbac.authorization.k8s.io"},
+		schema.GroupKind{Kind: "CustomResourceDefinition", Group: "apiextensions.k8s.io"},
+		schema.GroupKind{Kind: "SecurityContextConstraints", Group: "security.openshift.io"},
+		schema.GroupKind{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+		schema.GroupKind{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+		schema.GroupKind{Kind: "OAuth", Group: "config.openshift.io"},
+		schema.GroupKind{Kind: "Node", Group: "config.openshift.io"},
+		schema.GroupKind{Kind: "CloudCredential", Group: "operator.openshift.io"},
+		schema.GroupKind{Kind: "ConsolePlugin", Group: "console.openshift.io"},
+		schema.GroupKind{Kind: "MachineConfig", Group: "machineconfiguration.openshift.io"},
+		schema.GroupKind{Kind: "Template", Group: "template.openshift.io"},
 	)
-
 }

--- a/pkg/analyze/redhat/clusteroperator_test.go
+++ b/pkg/analyze/redhat/clusteroperator_test.go
@@ -13,7 +13,7 @@ import (
 func TestClusterOperatorAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 
-	e, _, objs := test.TestEvaluator("clusteroperators.yaml")
+	e, _, objs := test.TestEvaluator("clusteroperators.yaml", "authentication.yaml")
 
 	os = e.Eval(context.Background(), objs[0])
 	assert.False(t, os.Status().Progressing)
@@ -36,4 +36,12 @@ Available NotAvailable The service is not available (Error)
 Upgradeable AsExpected All is well (Unknown)
 EvaluationConditionsDetected NoData  (Unknown)
 `, os.Conditions)
+
+	// check status of related objects
+	assert.Len(t, os.SubStatuses, 1)
+	test.AssertConditions(t, `
+OAuthServiceDegraded   (Ok)
+APIServerDeploymentAvailable AsExpected  (Unknown)
+APIServerDeploymentDegraded AsExpected  (Ok)
+	`, os.SubStatuses[0].Conditions)
 }

--- a/pkg/analyze/redhat/testdata/authentication.yaml
+++ b/pkg/analyze/redhat/testdata/authentication.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: operator.openshift.io/v1
+    kind: Authentication
+    metadata:
+      annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/create-only: "true"
+      name: cluster
+      uid: 5a347d58-3053-427a-b621-48f99f36c623
+      ownerReferences:
+      - apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+        uid: 6f8b6c45-84c7-48cd-a9ce-5156dff71c55
+    spec:
+      logLevel: Normal
+      managementState: Managed
+      observedConfig: {}
+      operatorLogLevel: Normal
+      unsupportedConfigOverrides: null
+    status:
+      conditions:
+      - lastTransitionTime: "2025-05-26T07:11:44Z"
+        message: ""
+        reason: ""
+        status: "False"
+        type: OAuthServiceDegraded
+      - lastTransitionTime: "2025-05-26T07:19:18Z"
+        reason: AsExpected
+        status: "True"
+        type: APIServerDeploymentAvailable
+      - lastTransitionTime: "2025-05-26T07:19:18Z"
+        reason: AsExpected
+        status: "False"
+        type: APIServerDeploymentDegraded

--- a/pkg/analyze/redhat/testdata/clusteroperators.yaml
+++ b/pkg/analyze/redhat/testdata/clusteroperators.yaml
@@ -64,4 +64,8 @@ items:
       reason: NoData
       status: Unknown
       type: EvaluationConditionsDetected
+    relatedObjects:
+    - group: operator.openshift.io
+      name: cluster
+      resource: authentications
     extension: null

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -38,6 +38,9 @@ type Loader interface {
 
 	// LoadResources loads the resource based on its group resource, namespace and name
 	LoadResource(ctx context.Context, gvr schema.GroupResource, namespace string, name string) ([]*status.Object, error)
+
+	// ResourceToKind helps to translate a groupResource to the corresponding groupVersionKind
+	ResourceToKind(gr schema.GroupResource) schema.GroupVersionKind
 }
 
 // Evaluator is the entry structure for the status evaluation cycle.
@@ -165,6 +168,10 @@ func (e *Evaluator) EvalQuery(ctx context.Context, q QuerySpec, analyzer Analyze
 		ret = append(ret, a.Analyze(ctx, obj))
 	}
 	return ret, nil
+}
+
+func (e *Evaluator) ResourceToKind(gr schema.GroupResource) schema.GroupVersionKind {
+	return e.loader.ResourceToKind(gr)
 }
 
 // Load loads the objects specified by the query.

--- a/pkg/eval/fakeloader.go
+++ b/pkg/eval/fakeloader.go
@@ -52,8 +52,15 @@ func (l *FakeLoader) ResourceToKind(gr schema.GroupResource) schema.GroupVersion
 }
 
 func (l *FakeLoader) LoadResource(ctx context.Context, gr schema.GroupResource, namespace string, name string) ([]*status.Object, error) {
-	// noop
-	return []*status.Object{}, nil
+	r := []*status.Object{}
+	for _, v := range l.cache {
+		// this is not exact check (Kind comparison is missing) but right now it's sufficient for
+		// testing
+		if v.Name == name && v.GroupVersionKind().Group == gr.Group && v.Namespace == namespace {
+			r = append(r, v)
+		}
+	}
+	return r, nil
 }
 
 func (l *FakeLoader) LoadPodLogs(ctx context.Context, obj *status.Object, container string, tailLines int64) ([]byte, error) {

--- a/pkg/eval/fakeloader.go
+++ b/pkg/eval/fakeloader.go
@@ -46,6 +46,16 @@ func (l *FakeLoader) Load(ctx context.Context, ns string, matcher GroupKindMatch
 	return ret, nil
 }
 
+func (l *FakeLoader) ResourceToKind(gr schema.GroupResource) schema.GroupVersionKind {
+	// noop
+	return schema.GroupVersionKind{}
+}
+
+func (l *FakeLoader) LoadResource(ctx context.Context, gr schema.GroupResource, namespace string, name string) ([]*status.Object, error) {
+	// noop
+	return []*status.Object{}, nil
+}
+
 func (l *FakeLoader) LoadPodLogs(ctx context.Context, obj *status.Object, container string, tailLines int64) ([]byte, error) {
 	logs := l.podLogs[fmt.Sprintf("%s-%s-%s", obj.Namespace, obj.Name, container)]
 	return []byte(logs), nil

--- a/pkg/eval/realloader.go
+++ b/pkg/eval/realloader.go
@@ -23,7 +23,6 @@ import (
 // RealLoader is responsible for loading the objects from the cluster.
 type RealLoader struct {
 	client *client
-	mapper meta.RESTMapper
 }
 
 func NewRealLoader(config RESTClientGetter) (*RealLoader, error) {
@@ -132,7 +131,6 @@ type RESTClientGetter interface {
 type client struct {
 	dynamic      dynamicclient.Interface
 	mapper       meta.RESTMapper
-	config       *rest.Config
 	corev1client corev1client.CoreV1Interface
 	resources    resourcesMap
 }

--- a/pkg/eval/realloader.go
+++ b/pkg/eval/realloader.go
@@ -407,9 +407,9 @@ type groupVersionKindNamespaced struct {
 // which also has a flag whether it is a namespaced resource or not
 type resourcesMap map[schema.GroupResource]groupVersionKindNamespaced
 
-func (r *resourcesMap) namespacedResources() resourcesMap {
-	filtered := make(resourcesMap, len(*r))
-	for k, v := range *r {
+func (r resourcesMap) namespacedResources() resourcesMap {
+	filtered := make(resourcesMap, len(r))
+	for k, v := range r {
 		if v.namespaced {
 			filtered[k] = v
 		}
@@ -417,9 +417,9 @@ func (r *resourcesMap) namespacedResources() resourcesMap {
 	return filtered
 }
 
-func (r *resourcesMap) nonNamespacedResources() resourcesMap {
-	filtered := make(resourcesMap, len(*r))
-	for k, v := range *r {
+func (r resourcesMap) nonNamespacedResources() resourcesMap {
+	filtered := make(resourcesMap, len(r))
+	for k, v := range r {
 		if !v.namespaced {
 			filtered[k] = v
 		}
@@ -427,9 +427,9 @@ func (r *resourcesMap) nonNamespacedResources() resourcesMap {
 	return filtered
 }
 
-func (r *resourcesMap) toSlice() []schema.GroupVersionResource {
+func (r resourcesMap) toSlice() []schema.GroupVersionResource {
 	var s []schema.GroupVersionResource
-	for k, v := range *r {
+	for k, v := range r {
 		s = append(s, schema.GroupVersionResource{
 			Group:    k.Group,
 			Resource: k.Resource,


### PR DESCRIPTION
This is a proposal to extend the `ClusterOperator` analyzer to analyze the `relatedObjects` of the operator. 

I think having something like the `EvalResource` method (evaluate resource based on its `Group`, `Resource`) could be helpful in the future. 