### PR TITLE
feat: enable loading resource by label selector

### DIFF
--- a/pkg/eval/fakeloader.go
+++ b/pkg/eval/fakeloader.go
@@ -63,6 +63,11 @@ func (l *FakeLoader) LoadResource(ctx context.Context, gr schema.GroupResource, 
 	return r, nil
 }
 
+func (l *FakeLoader) LoadResourceBySelector(ctx context.Context, gr schema.GroupResource, namespace string, label string) ([]*status.Object, error) {
+	// noop
+	return nil, nil
+}
+
 func (l *FakeLoader) LoadPodLogs(ctx context.Context, obj *status.Object, container string, tailLines int64) ([]byte, error) {
 	logs := l.podLogs[fmt.Sprintf("%s-%s-%s", obj.Namespace, obj.Name, container)]
 	return []byte(logs), nil


### PR DESCRIPTION
This adds new functions to enable loading and evaluating a resource by a label selector. 
It also extends the `realloader_test.go` to increase the coverage of the new functions. 