### PR TITLE
feat: enable easier use as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ There are multiple waiting strategies implemented:
 If some resources are progressing, `8` is added to the exit code: use bitwise
 AND to extract this information.
 
+## Library usage
+
+You can use kube-health programmatically as a library via the `khealth` package, which provides a simple way to create and work with an Evaluator instance.
+
+```Go
+	evaluator, err := khealth.NewHealthEvaluator(nil)
+	if err != nil {
+		return err
+	}
+
+	statuses, err := evaluator.EvalResource(
+		context.Background(),
+		schema.GroupResource{Group: "", Resource: "nodes"},
+		"",
+		"master-node-name")
+```
+
 ## Use with Prometheus/Grafana
 
 Besides using `kube-health` from command line, it is possible to

--- a/pkg/khealth/khealth.go
+++ b/pkg/khealth/khealth.go
@@ -1,0 +1,70 @@
+package khealth
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/inecas/kube-health/pkg/analyze"
+	"github.com/inecas/kube-health/pkg/eval"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+// NewHealthEvaluator creates a new kube-health evaluator using the provided rest.Config.
+// If nil is passed, the in-cluster configuration will be used by default.
+func NewHealthEvaluator(restConfig *rest.Config) (*eval.Evaluator, error) {
+	var restClientGetter *restClientGETTER
+	if restConfig != nil {
+		restClientGetter = newRESTClientGETTER(restConfig)
+	} else {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		slog.Info("Using inClusterConfig")
+		restClientGetter = newRESTClientGETTER(config)
+	}
+
+	ldr, err := eval.NewRealLoader(restClientGetter)
+	if err != nil {
+		return nil, fmt.Errorf("can't create kube-health loader: %w", err)
+	}
+	return eval.NewEvaluator(analyze.DefaultAnalyzers(), ldr), nil
+}
+
+func newRESTClientGETTER(config *rest.Config) *restClientGETTER {
+	return &restClientGETTER{
+		rConfig: config,
+	}
+}
+
+// restClientGETTER is a wrapper around
+// provided rest.Config
+type restClientGETTER struct {
+	rConfig *rest.Config
+}
+
+func (r *restClientGETTER) ToRESTConfig() (*rest.Config, error) {
+	return r.rConfig, nil
+}
+
+func (r *restClientGETTER) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(r.rConfig)
+	if err != nil {
+		return nil, err
+	}
+	return memory.NewMemCacheClient(discoveryClient), nil
+}
+
+func (r *restClientGETTER) ToRESTMapper() (meta.RESTMapper, error) {
+	cli, err := r.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	deferredRESTMAPPER := restmapper.NewDeferredDiscoveryRESTMapper(cli)
+	return deferredRESTMAPPER, nil
+}

--- a/pkg/khealth/khealth.go
+++ b/pkg/khealth/khealth.go
@@ -1,3 +1,7 @@
+// Package khealth provides a way to use kube-health
+// as a library. The main usage is to create a new instance
+// of `eval.Evaluator` that can then be used programmatically to
+// evaluate the health of Kubernetes resources.
 package khealth
 
 import (


### PR DESCRIPTION
This is my (Friday's) suggestion to make it a little more simple to use kube-health as a library. I think it's better to introduce some new package (maybe some better name than `khealth` ?) to avoid cyclic dependencies. 