### PR TITLE
feat: simple analyzer for Node

### DIFF
--- a/pkg/analyze/common.go
+++ b/pkg/analyze/common.go
@@ -25,13 +25,18 @@ var (
 		{Kind: "EndpointSlice", Group: "discovery.k8s.io"},
 		{Kind: "Service", Group: ""},
 		{Kind: "ControllerRevision", Group: "apps"},
+		{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"},
+		{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"},
+		{Kind: "ClusterRole", Group: "authorization.openshift.io"},
+		{Kind: "ClusterRoleBinding", Group: "authorization.openshift.io"},
+		{Kind: "Project", Group: "project.openshift.io"},
 	}
 
 	// CommonConditionsAnalyzer is a generic condition analyzer that can be used
 	// for any condition type. It's one of the default analyzers.
 	CommonConditionsAnalyzer = GenericConditionAnalyzer{
 		Conditions: NewStringMatchers("Ready"),
-		ReversedPolarityConditions: append(NewRegexpMatchers("Degraded", "Pressure", "Detected"),
+		ReversedPolarityConditions: append(NewRegexpMatchers("Degraded", "Pressure", "Detected", "Terminating"),
 			NewStringMatchers("Progressing")...),
 		ProgressingConditions: NewStringMatchers("Progressing"),
 		WarningConditions:     NewRegexpMatchers("Pressure", "Detected"),

--- a/pkg/analyze/deployment_test.go
+++ b/pkg/analyze/deployment_test.go
@@ -1,7 +1,6 @@
 package analyze_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,10 +14,9 @@ import (
 func TestDeploymentAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 	p := print.NewTreePrinter(print.PrintOptions{ShowOk: true})
-	ctx := context.Background()
 	e, l, objs := test.TestEvaluator("deployments.yaml", "pods.yaml", "replicasets.yaml")
 
-	os = e.Eval(ctx, objs[0])
+	os = e.Eval(t.Context(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
@@ -42,7 +40,7 @@ Ok default/Deployment/dp1
 	`, sb.String())
 
 	l.RegisterPodLogs("default", "p2", "p2c", "Line 1\nLine 2\nLine 3\n")
-	os = e.Eval(ctx, objs[1])
+	os = e.Eval(t.Context(), objs[1])
 	assert.True(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/node.go
+++ b/pkg/analyze/node.go
@@ -1,0 +1,39 @@
+package analyze
+
+import (
+	"context"
+
+	"github.com/inecas/kube-health/pkg/eval"
+	"github.com/inecas/kube-health/pkg/status"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var gkNode = schema.GroupKind{Group: "", Kind: "Node"}
+
+type NodeAnalyzer struct {
+	e *eval.Evaluator
+}
+
+func (_ NodeAnalyzer) Supports(obj *status.Object) bool {
+	return obj.GroupVersionKind().GroupKind() == gkNode
+}
+
+func (a NodeAnalyzer) Analyze(ctx context.Context, obj *status.Object) status.ObjectStatus {
+	conditions, err := AnalyzeObjectConditions(obj, DefaultConditionAnalyzers)
+	if err != nil {
+		return status.UnknownStatusWithError(obj, err)
+	}
+
+	unschedulable, _, _ := unstructured.NestedBool(obj.Unstructured.Object, "spec", "unschedulable")
+	if unschedulable {
+		conditions = append(conditions, SyntheticConditionError("Unschedulable", "Unschedulable", "Node is marked as unschedulable"))
+	}
+	return AggregateResult(obj, nil, conditions)
+}
+
+func init() {
+	Register.Register(func(e *eval.Evaluator) eval.Analyzer {
+		return NodeAnalyzer{e: e}
+	})
+}

--- a/pkg/analyze/node_test.go
+++ b/pkg/analyze/node_test.go
@@ -1,0 +1,33 @@
+package analyze_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/inecas/kube-health/internal/test"
+	"github.com/inecas/kube-health/pkg/status"
+	"github.com/stretchr/testify/assert"
+)
+
+const healthyNodePressureConditions = `MemoryPressure KubeletHasSufficientMemory kubelet has sufficient memory available (Ok)
+DiskPressure KubeletHasNoDiskPressure kubelet has no disk pressure (Ok)
+PIDPressure KubeletHasSufficientPID kubelet has sufficient PID available (Ok)`
+
+func TestNodeAnalyzer(t *testing.T) {
+	var os status.ObjectStatus
+	e, _, objs := test.TestEvaluator("nodes.yaml")
+
+	os = e.Eval(t.Context(), objs[0])
+	assert.Equal(t, os.Status().Result, status.Error)
+	expectedConditions := fmt.Sprintf("%s\n%s\n%s\n%s", healthyNodePressureConditions,
+		"Ready KubeletNotReady test error message (Error)",
+		"Terminating TerminationRequested The cloud provider has marked this instance for termination (Error)",
+		"Unschedulable Unschedulable Node is marked as unschedulable (Error)",
+	)
+	test.AssertConditions(t, expectedConditions, os.Conditions)
+
+	os = e.Eval(t.Context(), objs[1])
+	assert.Equal(t, os.Status().Result, status.Ok)
+	expectedConditions = fmt.Sprintf("%s\n%s", healthyNodePressureConditions, "Ready KubeletReady  (Ok)")
+	test.AssertConditions(t, expectedConditions, os.Conditions)
+}

--- a/pkg/analyze/pod_test.go
+++ b/pkg/analyze/pod_test.go
@@ -1,7 +1,6 @@
 package analyze_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -12,15 +11,14 @@ import (
 
 func TestPodAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-	ctx := context.Background()
 	e, l, objs := test.TestEvaluator("pods.yaml")
 
-	os = e.Eval(ctx, objs[0])
+	os = e.Eval(t.Context(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
 	l.RegisterPodLogs("default", "p2", "p2c", "Line 1\nLine 2\nLine 3\n")
-	os = e.Eval(ctx, objs[1])
+	os = e.Eval(t.Context(), objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/pvc_test.go
+++ b/pkg/analyze/pvc_test.go
@@ -1,7 +1,6 @@
 package analyze_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -12,15 +11,14 @@ import (
 
 func TestPvcAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("pvcs.yaml")
 
-	os = e.Eval(ctx, objs[0])
+	os = e.Eval(t.Context(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 	test.AssertConditions(t, `Bound  PVC is bound. (Ok)`, os.Conditions)
 
-	os = e.Eval(ctx, objs[1])
+	os = e.Eval(t.Context(), objs[1])
 	assert.True(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Unknown)
 

--- a/pkg/analyze/replicaset_test.go
+++ b/pkg/analyze/replicaset_test.go
@@ -1,7 +1,6 @@
 package analyze_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -12,10 +11,9 @@ import (
 
 func TestReplicaSetAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
-	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("replicasets.yaml", "pods.yaml")
 
-	os = e.Eval(ctx, objs[1])
+	os = e.Eval(t.Context(), objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/service_test.go
+++ b/pkg/analyze/service_test.go
@@ -1,7 +1,6 @@
 package analyze_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,10 +14,9 @@ import (
 func TestServiceAnalyzer(t *testing.T) {
 	var os status.ObjectStatus
 	p := print.NewTreePrinter(print.PrintOptions{ShowOk: true})
-	ctx := context.Background()
 	e, _, objs := test.TestEvaluator("services.yaml", "pods.yaml")
 
-	os = e.Eval(ctx, objs[0])
+	os = e.Eval(t.Context(), objs[0])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Ok)
 
@@ -37,7 +35,7 @@ Ok default/Service/s1
                  Running=True                    24h
 `, sb.String())
 
-	os = e.Eval(ctx, objs[1])
+	os = e.Eval(t.Context(), objs[1])
 	assert.False(t, os.Status().Progressing)
 	assert.Equal(t, os.Status().Result, status.Error)
 

--- a/pkg/analyze/testdata/nodes.yaml
+++ b/pkg/analyze/testdata/nodes.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Node
+    metadata:
+      name: unschedulable-test-node
+      uid: 2d1efe7b-52aa-40a9-a93c-c5dbd25f85ac
+    spec:
+      unschedulable: true
+    status:
+      conditions:
+      - message: kubelet has sufficient memory available
+        reason: KubeletHasSufficientMemory
+        status: "False"
+        type: MemoryPressure
+      - message: kubelet has no disk pressure
+        reason: KubeletHasNoDiskPressure
+        status: "False"
+        type: DiskPressure
+      - message: kubelet has sufficient PID available
+        reason: KubeletHasSufficientPID
+        status: "False"
+        type: PIDPressure
+      - message: 'test error message'
+        reason: KubeletNotReady
+        status: "False"
+        type: Ready
+      - message: The cloud provider has marked this instance for termination
+        reason: TerminationRequested
+        status: "True"
+        type: Terminating
+  - apiVersion: v1
+    kind: Node
+    metadata:
+      name: healthy-test-node
+      uid: 3d1efe7b-52aa-40a9-a93c-c5dbd25f85ac
+    spec:
+    status:
+      conditions:
+      - message: kubelet has sufficient memory available
+        reason: KubeletHasSufficientMemory
+        status: "False"
+        type: MemoryPressure
+      - message: kubelet has no disk pressure
+        reason: KubeletHasNoDiskPressure
+        status: "False"
+        type: DiskPressure
+      - message: kubelet has sufficient PID available
+        reason: KubeletHasSufficientPID
+        status: "False"
+        type: PIDPressure
+      - message: ''
+        reason: KubeletReady
+        status: "True"
+        type: Ready

--- a/pkg/eval/realloader_test.go
+++ b/pkg/eval/realloader_test.go
@@ -1,7 +1,6 @@
 package eval
 
 import (
-	"context"
 	"testing"
 
 	"github.com/inecas/kube-health/pkg/status"
@@ -387,7 +386,7 @@ func TestLoadResource(t *testing.T) {
 				resources: allTestResources,
 			}
 			rl := RealLoader{client: c}
-			statusObjects, err := rl.LoadResource(context.Background(),
+			statusObjects, err := rl.LoadResource(t.Context(),
 				tt.testResource.gr, tt.testResource.namespace, tt.testResource.name)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatusObject, statusObjects)
@@ -475,7 +474,7 @@ func TestLoadResourceBySelector(t *testing.T) {
 				resources: allTestResources,
 			}
 			rl := RealLoader{client: c}
-			statusObjects, err := rl.LoadResourceBySelector(context.Background(),
+			statusObjects, err := rl.LoadResourceBySelector(t.Context(),
 				tt.testResource.gr, tt.testResource.namespace, tt.testResource.label)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatusObject, statusObjects)


### PR DESCRIPTION
This is a suggestion to add a simple `Node` analyzer checking if the node is marked as unschedulable. 