### PR TITLE
fix: avoid using "memory.NewMemCacheClient"

### DIFF
--- a/pkg/khealth/khealth.go
+++ b/pkg/khealth/khealth.go
@@ -6,69 +6,35 @@ package khealth
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/inecas/kube-health/pkg/analyze"
 	"github.com/inecas/kube-health/pkg/eval"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/discovery"
-	memory "k8s.io/client-go/discovery/cached"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 )
 
 // NewHealthEvaluator creates a new kube-health evaluator using the provided rest.Config.
 // If nil is passed, the in-cluster configuration will be used by default.
 func NewHealthEvaluator(restConfig *rest.Config) (*eval.Evaluator, error) {
-	var restClientGetter *restClientGETTER
+	cf := genericclioptions.NewConfigFlags(true)
+
 	if restConfig != nil {
-		restClientGetter = newRESTClientGETTER(restConfig)
+		cf.WrapConfigFn = func(*rest.Config) *rest.Config {
+			return restConfig
+		}
 	} else {
-		config, err := rest.InClusterConfig()
+		inClusterConf, err := rest.InClusterConfig()
 		if err != nil {
 			return nil, err
 		}
-		slog.Info("Using inClusterConfig")
-		restClientGetter = newRESTClientGETTER(config)
+		cf.WrapConfigFn = func(*rest.Config) *rest.Config {
+			return inClusterConf
+		}
 	}
 
-	ldr, err := eval.NewRealLoader(restClientGetter)
+	ldr, err := eval.NewRealLoader(cf)
 	if err != nil {
 		return nil, fmt.Errorf("can't create kube-health loader: %w", err)
 	}
 	return eval.NewEvaluator(analyze.DefaultAnalyzers(), ldr), nil
-}
-
-func newRESTClientGETTER(config *rest.Config) *restClientGETTER {
-	return &restClientGETTER{
-		rConfig: config,
-	}
-}
-
-// restClientGETTER is a wrapper around
-// provided rest.Config
-type restClientGETTER struct {
-	rConfig *rest.Config
-}
-
-func (r *restClientGETTER) ToRESTConfig() (*rest.Config, error) {
-	return r.rConfig, nil
-}
-
-func (r *restClientGETTER) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(r.rConfig)
-	if err != nil {
-		return nil, err
-	}
-	return memory.NewMemCacheClient(discoveryClient), nil
-}
-
-func (r *restClientGETTER) ToRESTMapper() (meta.RESTMapper, error) {
-	cli, err := r.ToDiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-
-	deferredRESTMAPPER := restmapper.NewDeferredDiscoveryRESTMapper(cli)
-	return deferredRESTMAPPER, nil
 }


### PR DESCRIPTION
This is to avoid using `memory.NewMemCacheClient` when using kube-health as a library. This client caches the information in memory and one should invalidate the cache regularly https://pkg.go.dev/k8s.io/client-go@v0.35.0/discovery/cached/memory#NewMemCacheClient. 

This can lead to errors as:
```
unable to retrieve the complete list of server APIs: subresources.kubevirt.io/v1: stale GroupVersion discovery
``` 
